### PR TITLE
Remove HipChat link from admin

### DIFF
--- a/resources/views/backend/shared/partials/footer.blade.php
+++ b/resources/views/backend/shared/partials/footer.blade.php
@@ -5,7 +5,6 @@
         <li><a href="https://cnvs.readme.io/docs" target="_blank">Documentation</a></li>
         <li><a href="https://cnvs.readme.io/blog" target="_blank">Blog</a></li>
         <li><a href="https://github.com/cnvs/canvas" target="_blank">GitHub</a></li>
-        <li><a href="https://cnvs.hipchat.com" target="_blank">HipChat</a></li>
         <li><a href="https://cnvs.readme.io/discuss" target="_blank">Support</a></li>
     </ul>
 </footer>


### PR DESCRIPTION
As the title explains. Removes the link to the inactive Hipchat room from the admin footer.
  
Related PR https://github.com/cnvs/easel/pull/165